### PR TITLE
Fix Brightness::DIMMEST, allow custom Brightness control

### DIFF
--- a/examples/.cargo/config.toml
+++ b/examples/.cargo/config.toml
@@ -1,5 +1,5 @@
 [target.'cfg(all(target_arch = "arm", target_os = "none"))']
-runner = "probe-run --chip RP2040"
+runner = "probe-rs run --chip RP2040 --protocol swd --speed 16000"
 
 [build]
 target = "thumbv6m-none-eabi"        # Cortex-M0 and Cortex-M0+

--- a/examples/src/bin/i2c.rs
+++ b/examples/src/bin/i2c.rs
@@ -27,9 +27,9 @@ bind_interrupts!(struct Irqs {
 async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
-
-    let scl = p.PIN_9;
-    let sda = p.PIN_8;
+    
+    let scl = p.PIN_13;
+    let sda = p.PIN_12;
     let mut config = Config::default();
     config.frequency = 400_000;
     let i2c = I2c::new_async(p.I2C0, scl, sda, Irqs, config);
@@ -39,18 +39,21 @@ async fn main(_spawner: Spawner) {
         .into_buffered_graphics_mode();
     display.init().await.unwrap();
 
+    
     let bmp = Bmp::from_slice(include_bytes!("../../rust.bmp")).expect("Failed to load BMP image");
-
+    
     // The image is an RGB565 encoded BMP, so specifying the type as `Image<Bmp<Rgb565>>` will read
     // the pixels correctly
     let im: Image<Bmp<Rgb565>> = Image::new(&bmp, Point::new(32, 0));
-
+    
     // We use the `color_converted` method here to automatically convert the RGB565 image data into
     // BinaryColor values.
     im.draw(&mut display.color_converted()).unwrap();
     display.flush().await.unwrap();
-
+    
     loop {
+        // Set the display brightness to maximum
+        display.set_brightness(Brightness::BRIGHTEST).await.unwrap();
         Timer::after(Duration::from_millis(1_000)).await;
         info!("Tick");
         display.clear();
@@ -67,6 +70,9 @@ async fn main(_spawner: Spawner) {
 
         display.flush().await.unwrap();
 
+        // Set the display brightness to minimum
+        display.set_brightness(Brightness::DIMMEST).await.unwrap();
+        
         Timer::after(Duration::from_millis(1_000)).await;
         info!("Tick");
         display.clear();

--- a/examples/src/bin/i2c.rs
+++ b/examples/src/bin/i2c.rs
@@ -28,8 +28,8 @@ async fn main(_spawner: Spawner) {
     let p = embassy_rp::init(Default::default());
     info!("Hello World!");
     
-    let scl = p.PIN_13;
-    let sda = p.PIN_12;
+    let scl = p.PIN_9;
+    let sda = p.PIN_8;
     let mut config = Config::default();
     config.frequency = 400_000;
     let i2c = I2c::new_async(p.I2C0, scl, sda, Irqs, config);
@@ -72,7 +72,7 @@ async fn main(_spawner: Spawner) {
 
         // Set the display brightness to minimum
         display.set_brightness(Brightness::DIMMEST).await.unwrap();
-        
+
         Timer::after(Duration::from_millis(1_000)).await;
         info!("Tick");
         display.clear();

--- a/src/brightness.rs
+++ b/src/brightness.rs
@@ -15,7 +15,7 @@ impl Default for Brightness {
 
 impl Brightness {
     /// The dimmest predefined brightness level
-    pub const DIMMEST: Brightness = Brightness::custom(0x1, 0x00);
+    pub const DIMMEST: Brightness = Brightness::custom(0x1, 0x01);
 
     /// A dim predefined brightness level
     pub const DIM: Brightness = Brightness::custom(0x2, 0x2F);
@@ -39,7 +39,7 @@ impl Brightness {
     ///
     /// `contrast` sets the value used in the `0x81 Set Contrast Control` command and must be
     /// between 0 and 255. See section 10.1.7 of the SSD1306 datasheet for more information.
-    const fn custom(precharge: u8, contrast: u8) -> Self {
+    pub const fn custom(precharge: u8, contrast: u8) -> Self {
         Self {
             precharge,
             contrast,


### PR DESCRIPTION
@kalkyl
- DIMMEST was effectively off because the contrast was zero
- made Brightness::custom public so that a user can have full control
- added Brightness to one example